### PR TITLE
Release/0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agaetis-react-scripts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Agaetis configuration and scripts for Create React App.",
   "repository": "Agaetis-IT/create-react-app",
   "license": "MIT",

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -43,10 +43,8 @@ module.exports = function (
     'lint:fix': 'node_modules/eslint/bin/eslint.js --fix src',
     'test': 'react-scripts test --env=jsdom',
     'eject': 'react-scripts eject',
+    "precommit": "yarn lint",
   };
-
-  // Lint before commit
-  appPackage['pre-commit'] = ["lint"];
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -37,18 +37,16 @@ module.exports = function (
 
   // Setup the script rules
   appPackage.scripts = {
-    start: 'react-scripts start',
-    build: 'react-scripts build',
-    lint: 'eslint src',
-    test: 'react-scripts test --env=jsdom',
-    eject: 'react-scripts eject',
+    'start': 'react-scripts start',
+    'build': 'react-scripts build',
+    'lint': 'node_modules/eslint/bin/eslint.js src',
+    'lint:fix': 'node_modules/eslint/bin/eslint.js --fix src',
+    'test': 'react-scripts test --env=jsdom',
+    'eject': 'react-scripts eject',
   };
 
   // Lint before commit
-  appPackage['pre-commit'] = [
-    "lint"
-  ];
-
+  appPackage['pre-commit'] = ["lint"];
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,18 +1,27 @@
 module.exports = {
-    "parser": "babel-eslint",
-    "extends": [
-        "standard",
-        "standard-react",
+  parser: 'babel-eslint',
+  extends: ['eslint:recommended', 'plugin:jest/recommended', 'plugin:react/recommended', 'prettier', 'prettier/react'],
+  plugins: ['jest', 'react', 'prettier'],
+  env: {
+    'jest/globals': true,
+    'browser': true,
+    'node': true,
+    'es6': true,
+  },
+  rules: {
+    'react/prop-types': 0,
+    'react/display-name': 0,
+    'react/no-unescaped-entities': 0,
+    "no-console": 0,
+    'no-unused-vars': ['error', { args: 'none' }],
+    'prettier/prettier': [
+      'error',
+      {
+        'printWidth': 120,
+        'semi': false,
+        'singleQuote': true,
+        'trailingComma': 'es5',
+      },
     ],
-    "plugins": [
-        "jest",
-    ],
-    "env": {
-        "jest/globals": true,
-        "browser": true,
-    },
-    "rules": {
-        "strict": 0,
-        "comma-dangle": ["error", "always-multiline"],
-    },
-};
+  },
+}

--- a/template/.template.dependencies.json
+++ b/template/.template.dependencies.json
@@ -19,6 +19,7 @@
     },
     "devDependencies": {
         "babel-eslint": "^8.0.2",
+        "husky": "^0.14.3",
         "eslint": "^4.11.0",
         "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-import": "^2.8.0",
@@ -27,7 +28,6 @@
         "eslint-plugin-prettier": "^2.6.0",
         "eslint-plugin-promise": "^3.6.0",
         "eslint-plugin-react": "^7.4.0",
-        "pre-commit": "^1.2.2",
         "prettier": "^1.11.1"
     }
 }

--- a/template/.template.dependencies.json
+++ b/template/.template.dependencies.json
@@ -20,14 +20,14 @@
     "devDependencies": {
         "babel-eslint": "^8.0.2",
         "eslint": "^4.11.0",
-        "eslint-config-standard": "^10.2.1",
-        "eslint-config-standard-react": "^5.0.0",
+        "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-import": "^2.8.0",
-        "eslint-plugin-jest": "^21.3.2",
+        "eslint-plugin-jest": "^21.15.0",
         "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-prettier": "^2.6.0",
         "eslint-plugin-promise": "^3.6.0",
         "eslint-plugin-react": "^7.4.0",
-        "eslint-plugin-standard": "^3.0.1",
-        "pre-commit": "^1.2.2"
+        "pre-commit": "^1.2.2",
+        "prettier": "^1.11.1"
     }
 }

--- a/template/src/Routes/index.js
+++ b/template/src/Routes/index.js
@@ -5,6 +5,6 @@ import Home from 'scenes/Home'
 
 export default () => (
   <Switch>
-    <Route path='/' component={Home} />
+    <Route path="/" component={Home} />
   </Switch>
 )

--- a/template/src/configureStore.js
+++ b/template/src/configureStore.js
@@ -15,14 +15,6 @@ const configureStore = () => {
 
   const store = createStore(rootReducer, composeEnhancers(applyMiddleware(...middlewares)))
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (module.hot) {
-      module.hot.accept('./reducers', () => {
-        store.replaceReducer(rootReducer)
-      })
-    }
-  }
-
   return { history, store }
 }
 

--- a/template/src/configureStore.js
+++ b/template/src/configureStore.js
@@ -1,32 +1,29 @@
-import { applyMiddleware, createStore } from 'redux' 
-import { composeWithDevTools } from 'redux-devtools-extension' 
-import thunk from 'redux-thunk' 
-import { routerMiddleware } from 'react-router-redux' 
-import createHistory from 'history/createBrowserHistory' 
- 
-import rootReducer from './reducers' 
- 
-const configureStore = () => { 
-  const history = createHistory() 
- 
-  const middlewares = [routerMiddleware(history), thunk] 
- 
-  const composeEnhancers = composeWithDevTools({}) 
- 
-  const store = createStore( 
-    rootReducer, 
-    composeEnhancers(applyMiddleware(...middlewares)) 
-  ) 
- 
-  if (process.env.NODE_ENV !== 'production') { 
-    if (module.hot) { 
-      module.hot.accept('./reducers', () => { 
-        store.replaceReducer(rootReducer) 
-      }) 
-    } 
-  } 
- 
-  return { history, store } 
-} 
- 
-export default configureStore 
+import { applyMiddleware, createStore } from 'redux'
+import { composeWithDevTools } from 'redux-devtools-extension'
+import thunk from 'redux-thunk'
+import { routerMiddleware } from 'react-router-redux'
+import createHistory from 'history/createBrowserHistory'
+
+import rootReducer from './reducers'
+
+const configureStore = () => {
+  const history = createHistory()
+
+  const middlewares = [routerMiddleware(history), thunk]
+
+  const composeEnhancers = composeWithDevTools({})
+
+  const store = createStore(rootReducer, composeEnhancers(applyMiddleware(...middlewares)))
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (module.hot) {
+      module.hot.accept('./reducers', () => {
+        store.replaceReducer(rootReducer)
+      })
+    }
+  }
+
+  return { history, store }
+}
+
+export default configureStore

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -23,19 +23,4 @@ ReactDOM.render(
   document.getElementById('root')
 )
 
-if (module.hot) {
-  module.hot.accept('/src', () => {
-    ReactDOM.render(
-      <Provider store={store}>
-        <MuiThemeProvider theme={theme}>
-          <ConnectedRouter history={history}>
-            <Routes />
-          </ConnectedRouter>
-        </MuiThemeProvider>
-      </Provider>,
-      document.getElementById('root')
-    )
-  })
-}
-
 registerServiceWorker()

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -4,13 +4,13 @@ import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'react-router-redux'
 import { MuiThemeProvider } from 'material-ui'
 
-import configureStore from './configureStore' 
+import configureStore from './configureStore'
 import theme from 'theme'
 import Routes from 'Routes'
 import registerServiceWorker from 'registerServiceWorker'
 import './index.css'
 
-const { store, history } = configureStore() 
+const { store, history } = configureStore()
 
 ReactDOM.render(
   <Provider store={store}>
@@ -20,21 +20,22 @@ ReactDOM.render(
       </ConnectedRouter>
     </MuiThemeProvider>
   </Provider>,
-  document.getElementById('root'))
+  document.getElementById('root')
+)
 
-if (module.hot) { 
-  module.hot.accept('./App', () => { 
-    ReactDOM.render( 
-      <Provider store={store}> 
-        <MuiThemeProvider theme={theme}> 
-          <ConnectedRouter history={history}> 
-            <App /> 
-          </ConnectedRouter> 
-        </MuiThemeProvider> 
-      </Provider>, 
-      document.getElementById('root') 
-    ) 
-  }) 
-} 
+if (module.hot) {
+  module.hot.accept('/src', () => {
+    ReactDOM.render(
+      <Provider store={store}>
+        <MuiThemeProvider theme={theme}>
+          <ConnectedRouter history={history}>
+            <Routes />
+          </ConnectedRouter>
+        </MuiThemeProvider>
+      </Provider>,
+      document.getElementById('root')
+    )
+  })
+}
 
 registerServiceWorker()

--- a/template/src/registerServiceWorker.js
+++ b/template/src/registerServiceWorker.js
@@ -10,15 +10,13 @@
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
-  // [::1] is the IPv6 localhost address.
-  window.location.hostname === '[::1]' ||
-  // 127.0.0.1/8 is considered localhost for IPv4.
-  window.location.hostname.match(
-    /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-  )
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 )
 
-export default function register () {
+export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location)
@@ -43,7 +41,7 @@ export default function register () {
   }
 }
 
-function registerValidSW (swUrl) {
+function registerValidSW(swUrl) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
@@ -72,15 +70,12 @@ function registerValidSW (swUrl) {
     })
 }
 
-function checkValidServiceWorker (swUrl) {
+function checkValidServiceWorker(swUrl) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      if (
-        response.status === 404 ||
-        response.headers.get('content-type').indexOf('javascript') === -1
-      ) {
+      if (response.status === 404 || response.headers.get('content-type').indexOf('javascript') === -1) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
           registration.unregister().then(() => {
@@ -93,13 +88,11 @@ function checkValidServiceWorker (swUrl) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      )
+      console.log('No internet connection found. App is running in offline mode.')
     })
 }
 
-export function unregister () {
+export function unregister() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {
       registration.unregister()

--- a/template/src/scenes/Home/index.js
+++ b/template/src/scenes/Home/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import logo from './logo.png'
 import './Home.css'
 
-class App extends Component {
+class Home extends Component {
   render () {
     return (
       <div className='App'>
@@ -18,4 +18,4 @@ class App extends Component {
   }
 }
 
-export default App
+export default Home

--- a/template/src/scenes/Home/index.js
+++ b/template/src/scenes/Home/index.js
@@ -3,14 +3,14 @@ import logo from './logo.png'
 import './Home.css'
 
 class Home extends Component {
-  render () {
+  render() {
     return (
-      <div className='App'>
-        <header className='App-header'>
-          <img src={logo} className='App-logo' alt='logo' />
-          <h1 className='App-title'>Welcome to React by Agaetis</h1>
+      <div className="App">
+        <header className="App-header">
+          <img src={logo} className="App-logo" alt="logo" />
+          <h1 className="App-title">Welcome to React by Agaetis</h1>
         </header>
-        <p className='App-intro'>
+        <p className="App-intro">
           To get started, edit <code>src/scenes/Home/index.js</code> and save to reload.
         </p>
       </div>

--- a/template/src/theme/index.js
+++ b/template/src/theme/index.js
@@ -1,5 +1,5 @@
 import { createMuiTheme } from 'material-ui/styles'
 
 export default createMuiTheme({
-// Configure your theme here
+  // Configure your theme here
 })


### PR DESCRIPTION
- Eslint/prettier with our "tolerant" config. Add `yarn lint` and `yarn lint:fix`.

- Husky instead of pre-commit. Husky doesn't need a specific bloc for the "precommit" commande and it seems a facebook practice (https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#formatting-code-automatically)

- Remove not working "hot.module" code. React-hot-loader need a `yarn eject` (https://github.com/gaearon/react-hot-loader#migrating-from-create-react-app). 
The alternative solution (without eject) isn't working with customs create-react-app (https://github.com/kitze/custom-react-scripts/issues/122) 

